### PR TITLE
Add config option to hide navigation button

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.10.18-flatlaf-SNAPSHOT'
+def runeLiteVersion = '1.10.21.1'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'com.radiusmarkers'
-version = '1.9.1'
+version = '1.9.2'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/radiusmarkers/RadiusMarkerConfig.java
+++ b/src/main/java/com/radiusmarkers/RadiusMarkerConfig.java
@@ -311,4 +311,15 @@ public interface RadiusMarkerConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "hideNavButton",
+		name = "Hide side panel button",
+		description = "Allows you to hide the side panel button to reduce clutter when not needing to modify Radius Markers",
+		position = 26
+	)
+	default boolean hideNavButton()
+	{
+		return false;
+	}
 }

--- a/src/main/java/com/radiusmarkers/RadiusMarkerPlugin.java
+++ b/src/main/java/com/radiusmarkers/RadiusMarkerPlugin.java
@@ -35,6 +35,7 @@ import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.game.SpriteManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
@@ -133,7 +134,11 @@ public class RadiusMarkerPlugin extends Plugin
 			.panel(pluginPanel)
 			.build();
 
-		clientToolbar.addNavigation(navigationButton);
+
+		if (!config.hideNavButton())
+		{
+			clientToolbar.addNavigation(navigationButton);
+		}
 	}
 
 	@Override
@@ -149,6 +154,26 @@ public class RadiusMarkerPlugin extends Plugin
 
 		pluginPanel = null;
 		navigationButton = null;
+	}
+
+	@Subscribe
+	public void onConfigChanged(final ConfigChanged configChanged)
+	{
+		if (!configChanged.getGroup().equals(CONFIG_GROUP))
+		{
+			return;
+		}
+		if (configChanged.getKey().equals("hideNavButton"))
+		{
+			if (config.hideNavButton())
+			{
+				clientToolbar.removeNavigation(navigationButton);
+			}
+			else
+			{
+				clientToolbar.addNavigation(navigationButton);
+			}
+		}
 	}
 
 	@Subscribe


### PR DESCRIPTION
Add config option to hide navigation button, to reduce clutter on side panel because the radius marker plugin is a set and forget type of plugin for many players