### PR TITLE
Chat success rates: fix progress bars bug + add mesbox support

### DIFF
--- a/src/main/java/com/chatsuccessrates/ChatSuccessRatesPlugin.java
+++ b/src/main/java/com/chatsuccessrates/ChatSuccessRatesPlugin.java
@@ -29,6 +29,7 @@ import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.util.ImageUtil;
 import static net.runelite.api.ChatMessageType.GAMEMESSAGE;
 import static net.runelite.api.ChatMessageType.SPAM;
+import static net.runelite.api.ChatMessageType.MESBOX;
 
 @PluginDescriptor(
 	name = "Chat Success Rates",
@@ -39,7 +40,8 @@ public class ChatSuccessRatesPlugin extends Plugin
 {
 	public static final Set<ChatMessageType> COLLAPSIBLE_MESSAGETYPES = ImmutableSet.of(
 		GAMEMESSAGE,
-		SPAM
+		SPAM,
+		MESBOX
 	);
 	public static final String CONFIG_GROUP = "chatsuccessrates";
 	private static final String MESSAGE_DELIM = "\n";

--- a/src/main/java/com/chatsuccessrates/trackers/CustomConfig.java
+++ b/src/main/java/com/chatsuccessrates/trackers/CustomConfig.java
@@ -10,6 +10,8 @@ import static com.chatsuccessrates.ChatSuccessRatesPlugin.COLLAPSIBLE_MESSAGETYP
 
 public class CustomConfig extends ChatSuccessRatesTracker
 {
+	private static final String MESSAGE_DELIM = "\n";
+
 	@Override
 	public ChatSuccessRatesSkill getSkill()
 	{
@@ -45,13 +47,19 @@ public class CustomConfig extends ChatSuccessRatesTracker
 		final int level = ChatSuccessRatesSkill.CUSTOM.equals(skill) ? client.getTotalLevel() :
 			(config.useBoostedLevel() ? client.getBoostedSkillLevel(skill.getSkill()) : client.getRealSkillLevel(skill.getSkill()));
 
-		if (config.messageSuccess().equals(message))
+		for (String successMessage : config.messageSuccess().split(MESSAGE_DELIM))
 		{
-			update(level, 1, 0);
+			if (message.equals(successMessage))
+			{
+				update(level, 1, 0);
+			}
 		}
-		else if (config.messageFailure().equals(message))
+		for (String failureMessage : config.messageFailure().split(MESSAGE_DELIM))
 		{
-			update(level, 0, 1);
+			if (message.equals(failureMessage))
+			{
+				update(level, 0, 1);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Hello, I'm micro on discord, I noticed a bug where the progress bars weren't updating when I had multiple success/failure messages. It was just an issue of CustomConfig.java still using .equals() instead of looping through the messages.

I also added tracking for mesbox messages, since we're collecting some data right now where the text in a message box is the "success" numerator. I did not do anything like having that message repeat as a game message with the duplicate (#) stuff, so they're only tracked via the progress bars right now.