### PR TITLE
identificator: Use correct bitfield to find tile object type

### DIFF
--- a/src/main/java/com/identificator/IdentificatorPlugin.java
+++ b/src/main/java/com/identificator/IdentificatorPlugin.java
@@ -256,7 +256,7 @@ public class IdentificatorPlugin extends Plugin
 		// 1 = NPC
 		// 2 = Object
 		// 3 = Item
-		return gameObject != null && (gameObject.getHash() >> 14 & 3) == 2;
+		return gameObject != null && (gameObject.getHash() >> 16 & 7) == 2;
 	}
 
 	public ObjectComposition getMorphedGameObject(GameObject gameObject)


### PR DESCRIPTION
Fixes game object identifying. Idk if this function is redundant since we have instances of `GameObject` anyway, but at least this fixes the feature.

See https://static.runelite.net/runelite-api/apidocs/net/runelite/api/TileObject.html#getHash()